### PR TITLE
troubleshooting async and multithreading issues

### DIFF
--- a/client.py
+++ b/client.py
@@ -2,18 +2,22 @@ import concurrent.futures
 import requests
 import os
 import io
+from datetime import datetime
 import time
+import httpx
+import asyncio
+import aiohttp
 
 chunk_size = 1024  * 1024 * 8
 DEBUG = False
 UPLOAD_URL='http://127.0.0.1:8000/upload'
 PURGE_URL='http://127.0.0.1:8000/purge'
-FILES_TO_UPLOAD = ['/test/directory/5gigfile', 
-'/test/directory/10gigfile',
-'/test/directory/15gigfile',
-'/test/directory/20gigfile']
+FILES_TO_UPLOAD = [
+    '/Users/dennis/rcsb/py-rcsb_app_file/rcsb/app/tests-file/test-data/bigFile.txt.256mb',
+]
 
 def serial_test():
+    print(datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3])
     print(f'Uploading {len(FILES_TO_UPLOAD)} files serially')
     results = []
     for file in FILES_TO_UPLOAD:
@@ -21,17 +25,20 @@ def serial_test():
     print("Serial Uploading Result")
     for result in results:
         print(result)
+    print(datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3])
 
 def concurrent_test():
+        print(datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3])
         print(f'Uploading {len(FILES_TO_UPLOAD)} files with threadpool')
-        with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
             futures = {executor.submit(upload_file, file): file for file in FILES_TO_UPLOAD}
-            results = []
-            for future in concurrent.futures.as_completed(futures):
-                results.append(future.result())
-            print("Multi-threaded multiple files result")
-            for result in results:
-                print(result)
+            # results = []
+            # for future in concurrent.futures.as_completed(futures):
+            #     results.append(future.result())
+            # print("Multi-threaded multiple files result")
+            # for result in results:
+                # print(result)
+        print(datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3])
 
 def human_friendly(bites):
     unit = "B"
@@ -65,8 +72,25 @@ def testing_stats(func):
             return None
     return get_statistics
 
-def async_request(req_body, tmp):
-    return requests.post(UPLOAD_URL,data=req_body, files={'file' : tmp})
+async def gather_async_request(file_path, req_body):
+    tL = []
+    tmp =  io.BytesIO()
+    with requests.Session() as client:
+        with open(file_path, "rb") as to_upload:
+            for i in range(0, req_body["total_chunks"]):
+                req_body["total_chunks_uploaded"]+=1
+                packet_size =min(req_body["file_size"] - (i*chunk_size), chunk_size)
+                req_body["chunk_index"] = i
+                req_body["chunk_byte_offset"] = req_body["chunk_index"] * chunk_size
+                tmp.truncate(packet_size)
+                tmp.seek(0)
+                tmp.write(to_upload.read(packet_size))
+                tmp.seek(0)
+                tL.append(client.post(UPLOAD_URL,data=req_body, files={'file' : tmp}))
+        # res = await asyncio.gather(*tL)
+        # print("res", res)
+        # return res
+        return await asyncio.gather(*tL)
 
 @testing_stats
 def upload_file(file_path):
@@ -86,45 +110,34 @@ def upload_file(file_path):
         "chunk_index" : 0,
         "chunk_byte_offset" : 0,
         "total_chunks" : total_chunks,
+        "total_chunks_uploaded" : 0,
         "file_size" : file_size
     }
 
     if ASYNC:
-        pool = concurrent.futures.ThreadPoolExecutor(max_workers=10)
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)  # FASTER WITH "1" instead of "10"?! That pointed out, true "async" should occur only on one thread...
 
     tmp =  io.BytesIO()
-    with open(file_path, "rb") as to_upload:
-        for i in range(0, req_body["total_chunks"]):
-            packet_size =min(req_body["file_size"] - (req_body["chunk_index"]*chunk_size), chunk_size)
-            tmp.truncate(packet_size)
-            tmp.seek(0)
-            tmp.write(to_upload.read(packet_size))
-            tmp.seek(0)
-            if ASYNC:
-               response = pool.submit(async_request,req_body, tmp) 
-            else:
-                response = requests.post(UPLOAD_URL,data=req_body, files={'file' : tmp})
-            if DEBUG and not ASYNC:
-                print(str(response.content))
-            if not ASYNC and response.status_code != 200:
-                break
-            req_body["chunk_index"] = req_body["chunk_index"] + 1
-            req_body["chunk_byte_offset"] = req_body["chunk_index"] * chunk_size
-    return response
+
+    tot= 0
+    total_chunks_uploaded =0
+    response = asyncio.run(gather_async_request(file_path, req_body))
+    # return response
+    return
 
 
 
 if __name__ == "__main__":
-    print('Without ASYNC')
-    ASYNC=False 
-    response = requests.get(PURGE_URL)
-    serial_test() # Each file is uploaded one after another
-    response = requests.get(PURGE_URL) 
-    concurrent_test() # 10 files being uploaded concurrently
+    # print('Without ASYNC')
+    # ASYNC=False 
+    # response = requests.get(PURGE_URL)
+    # serial_test() # Each file is uploaded one after another
+    # response = requests.get(PURGE_URL) 
+    # concurrent_test() # 10 files being uploaded concurrently
 
     print('With ASYNC')
     ASYNC=True # Same file can have upto 10 chunks sent concurrently
-    response = requests.get(PURGE_URL)
-    serial_test()
+    # response = requests.get(PURGE_URL)
+    # serial_test()
     response = requests.get(PURGE_URL)
     concurrent_test()

--- a/client.py
+++ b/client.py
@@ -2,22 +2,21 @@ import concurrent.futures
 import requests
 import os
 import io
-from datetime import datetime
 import time
-import httpx
-import asyncio
-import aiohttp
+from copy import deepcopy
 
-chunk_size = 1024  * 1024 * 8
+chunk_size = 1024 * 1024 * 8
 DEBUG = False
-UPLOAD_URL='http://127.0.0.1:8000/upload'
-PURGE_URL='http://127.0.0.1:8000/purge'
+UPLOAD_URL = 'http://127.0.0.1:8000/upload'
+PURGE_URL = 'http://127.0.0.1:8000/purge'
 FILES_TO_UPLOAD = [
+    '/Users/dennis/rcsb/py-rcsb_app_file/rcsb/app/tests-file/test-data/bigFile.txt',
     '/Users/dennis/rcsb/py-rcsb_app_file/rcsb/app/tests-file/test-data/bigFile.txt.256mb',
+    # '/Users/dennis/rcsb/py-rcsb_app_file/rcsb/app/tests-file/test-data/bigFile.txt.14gb',
+    # '/Users/dennis/rcsb/py-rcsb_app_file/rcsb/app/tests-file/test-data/bigFile.txt.30gb',
 ]
 
 def serial_test():
-    print(datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3])
     print(f'Uploading {len(FILES_TO_UPLOAD)} files serially')
     results = []
     for file in FILES_TO_UPLOAD:
@@ -25,30 +24,27 @@ def serial_test():
     print("Serial Uploading Result")
     for result in results:
         print(result)
-    print(datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3])
 
 def concurrent_test():
-        print(datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3])
-        print(f'Uploading {len(FILES_TO_UPLOAD)} files with threadpool')
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            futures = {executor.submit(upload_file, file): file for file in FILES_TO_UPLOAD}
-            # results = []
-            # for future in concurrent.futures.as_completed(futures):
-            #     results.append(future.result())
-            # print("Multi-threaded multiple files result")
-            # for result in results:
-                # print(result)
-        print(datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3])
+    print(f'Uploading {len(FILES_TO_UPLOAD)} files with threadpool')
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        futures = {executor.submit(upload_file, file): file for file in FILES_TO_UPLOAD}
+        results = []
+        for future in concurrent.futures.as_completed(futures):
+            results.append(future.result())
+        print("Multi-threaded multiple files result")
+        for result in results:
+            print(result)
 
 def human_friendly(bites):
     unit = "B"
-    if bites >1024:
+    if bites > 1024:
         bites = bites/1024
-        unit ='KB'
-    if bites>1024:
+        unit = 'KB'
+    if bites > 1024:
         bites = bites/1024
         unit = 'MB'
-    if bites>1024:
+    if bites > 1024:
         bites = bites/1024
         unit = 'GB'
     return f"{bites} {unit}"
@@ -56,13 +52,13 @@ def human_friendly(bites):
 def testing_stats(func):
     '''For calculating time for a given function'''
     def get_statistics(*args, **kwargs):
-        timings={}
+        timings = {}
         file_path = args[0]
         size = os.path.getsize(file_path)
         timings['File_size'] = human_friendly(size)
         start = time.time()
         r = func(*args, **kwargs)
-        if isinstance(r,concurrent.futures.Future):
+        if isinstance(r, concurrent.futures.Future):
             r = r.result()
         if r.status_code == 200:
             timings['Duration'] = time.time() - start
@@ -72,25 +68,8 @@ def testing_stats(func):
             return None
     return get_statistics
 
-async def gather_async_request(file_path, req_body):
-    tL = []
-    tmp =  io.BytesIO()
-    with requests.Session() as client:
-        with open(file_path, "rb") as to_upload:
-            for i in range(0, req_body["total_chunks"]):
-                req_body["total_chunks_uploaded"]+=1
-                packet_size =min(req_body["file_size"] - (i*chunk_size), chunk_size)
-                req_body["chunk_index"] = i
-                req_body["chunk_byte_offset"] = req_body["chunk_index"] * chunk_size
-                tmp.truncate(packet_size)
-                tmp.seek(0)
-                tmp.write(to_upload.read(packet_size))
-                tmp.seek(0)
-                tL.append(client.post(UPLOAD_URL,data=req_body, files={'file' : tmp}))
-        # res = await asyncio.gather(*tL)
-        # print("res", res)
-        # return res
-        return await asyncio.gather(*tL)
+def async_request(req_body, tmp):
+    return requests.post(UPLOAD_URL, data=req_body, files={'file': tmp})
 
 @testing_stats
 def upload_file(file_path):
@@ -106,38 +85,49 @@ def upload_file(file_path):
         total_chunks = 1
 
     req_body = {
-        "file_name" : file_path.split('/')[-1],
-        "chunk_index" : 0,
-        "chunk_byte_offset" : 0,
-        "total_chunks" : total_chunks,
-        "total_chunks_uploaded" : 0,
-        "file_size" : file_size
+        "file_name": file_path.split('/')[-1],
+        "chunk_index": 0,
+        "chunk_byte_offset": 0,
+        "total_chunks": total_chunks,
+        "file_size": file_size
     }
 
     if ASYNC:
-        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)  # FASTER WITH "1" instead of "10"?! That pointed out, true "async" should occur only on one thread...
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=10)
 
-    tmp =  io.BytesIO()
-
-    tot= 0
-    total_chunks_uploaded =0
-    response = asyncio.run(gather_async_request(file_path, req_body))
-    # return response
-    return
-
+    tmp = io.BytesIO()
+    with open(file_path, "rb") as to_upload:
+        for i in range(0, req_body["total_chunks"]):
+            packet_size = min(req_body["file_size"] - (req_body["chunk_index"]*chunk_size), chunk_size)
+            tmp.truncate(packet_size)
+            tmp.seek(0)
+            tmp.write(to_upload.read(packet_size))
+            tmp.seek(0)
+            if ASYNC:
+                # print(req_body)
+                response = pool.submit(async_request, deepcopy(req_body), deepcopy(tmp))
+            else:
+                response = requests.post(UPLOAD_URL, data=req_body, files={'file': tmp})
+            if DEBUG and not ASYNC:
+                print(str(response.content))
+            if not ASYNC and response.status_code != 200:
+                break
+            req_body["chunk_index"] = req_body["chunk_index"] + 1
+            req_body["chunk_byte_offset"] = req_body["chunk_index"] * chunk_size
+    return response
 
 
 if __name__ == "__main__":
-    # print('Without ASYNC')
-    # ASYNC=False 
-    # response = requests.get(PURGE_URL)
-    # serial_test() # Each file is uploaded one after another
-    # response = requests.get(PURGE_URL) 
-    # concurrent_test() # 10 files being uploaded concurrently
+    print('Without ASYNC')
+    ASYNC = False
+    response = requests.get(PURGE_URL)
+    serial_test()  # Each file is uploaded one after another
+    response = requests.get(PURGE_URL)
+    concurrent_test()  # 10 files being uploaded concurrently
 
     print('With ASYNC')
-    ASYNC=True # Same file can have upto 10 chunks sent concurrently
-    # response = requests.get(PURGE_URL)
-    # serial_test()
+    ASYNC = True  # Same file can have upto 10 chunks sent concurrently
+    response = requests.get(PURGE_URL)
+    serial_test()
     response = requests.get(PURGE_URL)
     concurrent_test()

--- a/main.py
+++ b/main.py
@@ -1,7 +1,14 @@
+"""
+Run with `uvicorn main:app`
+
+Then run `python client.py`
+"""
+
 from fastapi import FastAPI, Form, UploadFile, HTTPException
 import glob
 import os
 import logging
+from time import sleep
 
 app = FastAPI()
 log = logging.getLogger(__name__)
@@ -20,6 +27,7 @@ async def upload(file: UploadFile,
     chunk_index : int = Form(...),
     chunk_byte_offset: int = Form(...),
     total_chunks : int = Form(...),
+    total_chunks_uploaded : int = Form(...),
     file_size : int = Form(...) ):
 
     save_path = os.path.join(DATA_DIR, file_name)
@@ -34,8 +42,12 @@ async def upload(file: UploadFile,
     except OSError:
         log.exception('Could not write to file')
         raise HTTPException(status_code=500, detail="Could not write to file")
-    if chunk_index + 1 == total_chunks:
+    print("save_path size: ", os.path.getsize(save_path), "file_size", file_size)
+    print("chunk index / total chunks", chunk_index, total_chunks)
+    print("total_chunks_uploaded / total chunks", total_chunks_uploaded, total_chunks)
+    if total_chunks_uploaded == total_chunks:
         if os.path.getsize(save_path) != file_size:
+            print("BAD save_path size: ", os.path.getsize(save_path), "file_size", file_size)
             log.error(f"File {file_name} was completed, "
                       f"but has a size mismatch."
                       f"Was {os.path.getsize(save_path)} but we"

--- a/main.py
+++ b/main.py
@@ -8,11 +8,17 @@ from fastapi import FastAPI, Form, UploadFile, HTTPException
 import glob
 import os
 import logging
-from time import sleep
 
 app = FastAPI()
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s]-%(module)s.%(funcName)s: %(message)s")
 log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
 DATA_DIR = "data"
+if not os.path.exists(DATA_DIR):
+    os.mkdir(DATA_DIR)
+
+sessionD = {}
 
 @app.get("/purge")
 def purge():
@@ -20,21 +26,28 @@ def purge():
     files = glob.glob(f'{cwd}/{DATA_DIR}/*')
     for f in files:
         os.remove(f)
-        
-@app.post("/upload")
-async def upload(file: UploadFile, 
-    file_name : str = Form(...),
-    chunk_index : int = Form(...),
-    chunk_byte_offset: int = Form(...),
-    total_chunks : int = Form(...),
-    total_chunks_uploaded : int = Form(...),
-    file_size : int = Form(...) ):
 
+@app.post("/upload")
+async def upload(file: UploadFile,
+    file_name: str = Form(...),
+    chunk_index: int = Form(...),
+    chunk_byte_offset: int = Form(...),
+    total_chunks: int = Form(...),
+    file_size: int = Form(...)
+):
+    #
+    if file_name not in sessionD:
+        sessionD.update({file_name: 0})
+    else:
+        sessionD[file_name] += 1
+    #
+    # log.info("sessionD %r", sessionD)
+    #
     save_path = os.path.join(DATA_DIR, file_name)
-    if os.path.exists(save_path) and chunk_index == 0:
+    if os.path.exists(save_path) and sessionD[file_name] == 0:
         log.error('File already exist. Remove it from the upload directory')
         raise HTTPException(status_code=500, detail="File already exists. ")
-        
+    #
     try:
         with open(save_path, 'ab') as f:
             f.seek(chunk_byte_offset)
@@ -42,20 +55,23 @@ async def upload(file: UploadFile,
     except OSError:
         log.exception('Could not write to file')
         raise HTTPException(status_code=500, detail="Could not write to file")
-    print("save_path size: ", os.path.getsize(save_path), "file_size", file_size)
-    print("chunk index / total chunks", chunk_index, total_chunks)
-    print("total_chunks_uploaded / total chunks", total_chunks_uploaded, total_chunks)
-    if total_chunks_uploaded == total_chunks:
+    #
+    # log.info("chunk_index %r, total_chunks %r", chunk_index, total_chunks)
+    # log.info("save_path_size %r, file_size %r", os.path.getsize(save_path), file_size)
+    #
+    if sessionD[file_name] + 1 == total_chunks:
         if os.path.getsize(save_path) != file_size:
-            print("BAD save_path size: ", os.path.getsize(save_path), "file_size", file_size)
-            log.error(f"File {file_name} was completed, "
-                      f"but has a size mismatch."
-                      f"Was {os.path.getsize(save_path)} but we"
-                      f" expected {file_size} ")
+            log.error(
+                f"File {file_name} was completed, "
+                f"but has a size mismatch."
+                f"Was {os.path.getsize(save_path)} but we"
+                f" expected {file_size} "
+            )
             raise HTTPException(status_code=500, detail="size mismatch")
         else:
             log.info(f'File {file_name} has been uploaded successfully')
+            del sessionD[file_name]
     else:
         log.debug(f'Chunk {chunk_index + 1} of {total_chunks} '
                   f'for file {file_name} complete')
-    return {"message":f"Chunk #{chunk_index} upload successful for {file_name} "}
+    return {"message": f"Chunk #{chunk_index} upload successful for {file_name} "}


### PR DESCRIPTION
Discovered that previous benchmarks were not totally accurate...comparing the files before and after upload, they differed. Apparently, the `upload` endpoint was receiving signal that all parts of the upload had completed prior to them actually completing. This means that our benchmarks looked significantly better than they actually were.

~~Here, I've tried to await the async calls so that they finish before being signaled as having completed. Also, the `chunk_index` didn't seem to be incremented properly.~~

~~Bugs to still address—commenting in [these lines](https://github.com/Smat26/Fastapi-file-upload/blob/15cc0066e02562d4b2f0dee685adfdf21a192ed1/client.py#L35-L40) of `concurrent_test` results in some async errors...:~~

**EDIT:**
After working through code together in hackathon, identified and fixed the true sources of the issue. However, excess memory usage is now a new problem to address next.

Current benchmarks for two 256mb files:
```
Without ASYNC
Uploading 2 files serially
Serial Uploading Result
{'File_size': '256.0 MB', 'Duration': 4.438616037368774}
{'File_size': '256.0 MB', 'Duration': 4.201501846313477}
Uploading 2 files with threadpool
Multi-threaded multiple files result
{'File_size': '256.0 MB', 'Duration': 6.87183690071106}
{'File_size': '256.0 MB', 'Duration': 6.984889984130859}
With ASYNC
Uploading 2 files serially
Serial Uploading Result
{'File_size': '256.0 MB', 'Duration': 3.00715708732605}
{'File_size': '256.0 MB', 'Duration': 3.048976182937622}
Uploading 2 files with threadpool
Multi-threaded multiple files result
{'File_size': '256.0 MB', 'Duration': 5.969863176345825}
{'File_size': '256.0 MB', 'Duration': 5.9876580238342285}
```